### PR TITLE
Update to Custom Vision SDK 2.0

### DIFF
--- a/COCOCustomVisionTrainer/COCOCustomVisionTrainer.csproj
+++ b/COCOCustomVisionTrainer/COCOCustomVisionTrainer.csproj
@@ -32,23 +32,27 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training, Version=0.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training.0.10.0-preview\lib\net452\Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training.dll</HintPath>
+    <Reference Include="Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training.2.0.0\lib\net461\Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.CommandLineUtils, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.CommandLineUtils.1.1.1\lib\net451\Microsoft.Extensions.CommandLineUtils.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.11\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.20\lib\net461\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.Azure.3.3.12\lib\net452\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.Azure.3.3.18\lib\net452\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/COCOCustomVisionTrainer/Program.cs
+++ b/COCOCustomVisionTrainer/Program.cs
@@ -28,6 +28,10 @@ namespace COCOCustomVisionTrainer
               "-tkey | --trainingKey", 
               "Provide your Custom Vision training key (https://www.customvision.ai/projects#/settings) as -tkey | --trainingKey YOUR_KEY",
               CommandOptionType.SingleValue);
+            CommandOption trainingEndoint = commandLineApplication.Option(
+              "-tendpoint | --trainingEndpoint",
+              "Provide your Custom Vision training base URL endpoint as -tendpoint | --trainingEndpoint ENDPOINT",
+              CommandOptionType.SingleValue);
             CommandOption filePath = commandLineApplication.Option(
               "-f | --fileDatasetJSON",
               "Provide a path or URL of a COCO Train/Val annonations JSON file as -f | --fileDatasetJSON instances_train*.json or instances_val*.json. " +
@@ -84,7 +88,7 @@ namespace COCOCustomVisionTrainer
 
                     try
                     {
-                        var t = WorkOnProject(trainingKey.Value(), projectName.Value(), filePath.Value(),
+                        var t = WorkOnProject(trainingEndoint.Value(), trainingKey.Value(), projectName.Value(), filePath.Value(),
                             categoriesList, numberOfImagesToUse,
                             isDetectionModel.HasValue(), train.HasValue());
                         t.Wait();
@@ -116,7 +120,7 @@ namespace COCOCustomVisionTrainer
             return commandLineApplication.Execute(args);
         }
 
-        static async Task WorkOnProject(string trainingKey, string projectName, string COCOInstancesFilePathOrUrl, IList<string> categories, uint numberOfImages, bool isDetectionModel, bool train)
+        static async Task WorkOnProject(string trainingEndpoint, string trainingKey, string projectName, string COCOInstancesFilePathOrUrl, IList<string> categories, uint numberOfImages, bool isDetectionModel, bool train)
         {
             Console.Write($"\nLoading, parsing and preparing {COCOInstancesFilePathOrUrl}...");
 
@@ -131,7 +135,7 @@ namespace COCOCustomVisionTrainer
             Console.WriteLine("Prepared COCO dataset with {0} categories and {1} images.\n", data.categoriesAndIds.Count, data.traningSet.Count);
 
             Console.Write($"Initializing Custom Vision Project {COCOInstancesFilePathOrUrl}...");
-            ProjectTraningConfiguration trainingConfig = await ProjectTraningConfiguration.CreateProjectAsync(trainingKey, projectName, true, isDetectionModel);
+            ProjectTraningConfiguration trainingConfig = await ProjectTraningConfiguration.CreateProjectAsync(trainingEndpoint,trainingKey, projectName, true, isDetectionModel);
             Console.WriteLine("done.");
 
             Console.Write($"\nLoading traning images to Custom Vision Project...");

--- a/CustomVision.COCO/CustomVision.COCO.csproj
+++ b/CustomVision.COCO/CustomVision.COCO.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.CustomVision.Prediction" Version="0.10.0-preview" />
-    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training" Version="0.10.0-preview" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.11" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.CustomVision.Prediction" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.22" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
I updated the code to match version 2.0 of Custom Vision SDK.
- Added a new parameter, trainEndpoint to specify the base endpoint URL to of from the Custom Vision service. If not specified shared base endpoint will be used. 